### PR TITLE
Generate test ingredients properly, add view model, reorder supported units

### DIFF
--- a/DogFoodCalculator/DogFoodCalculator.xcodeproj/xcuserdata/roshan.xcuserdatad/xcschemes/DogFoodCalculator.xcscheme
+++ b/DogFoodCalculator/DogFoodCalculator.xcodeproj/xcuserdata/roshan.xcuserdatad/xcschemes/DogFoodCalculator.xcscheme
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0900"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "01C704B51FAA617E0001BFBD"
+               BuildableName = "DogFoodCalculator.app"
+               BlueprintName = "DogFoodCalculator"
+               ReferencedContainer = "container:DogFoodCalculator.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "014AB0DB1FABAC1D006ABF3E"
+               BuildableName = "DogFoodCalculatorTests.xctest"
+               BlueprintName = "DogFoodCalculatorTests"
+               ReferencedContainer = "container:DogFoodCalculator.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "01C704B51FAA617E0001BFBD"
+            BuildableName = "DogFoodCalculator.app"
+            BlueprintName = "DogFoodCalculator"
+            ReferencedContainer = "container:DogFoodCalculator.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "01C704B51FAA617E0001BFBD"
+            BuildableName = "DogFoodCalculator.app"
+            BlueprintName = "DogFoodCalculator"
+            ReferencedContainer = "container:DogFoodCalculator.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Debug"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "01C704B51FAA617E0001BFBD"
+            BuildableName = "DogFoodCalculator.app"
+            BlueprintName = "DogFoodCalculator"
+            ReferencedContainer = "container:DogFoodCalculator.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/DogFoodCalculator/DogFoodCalculator.xcodeproj/xcuserdata/roshan.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/DogFoodCalculator/DogFoodCalculator.xcodeproj/xcuserdata/roshan.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -10,5 +10,18 @@
 			<integer>0</integer>
 		</dict>
 	</dict>
+	<key>SuppressBuildableAutocreation</key>
+	<dict>
+		<key>014AB0DB1FABAC1D006ABF3E</key>
+		<dict>
+			<key>primary</key>
+			<true/>
+		</dict>
+		<key>01C704B51FAA617E0001BFBD</key>
+		<dict>
+			<key>primary</key>
+			<true/>
+		</dict>
+	</dict>
 </dict>
 </plist>

--- a/DogFoodCalculator/DogFoodCalculator/Controllers/DFCalculatorViewController.swift
+++ b/DogFoodCalculator/DogFoodCalculator/Controllers/DFCalculatorViewController.swift
@@ -21,7 +21,7 @@ class DFCalculatorViewController: UIViewController {
     super.loadView()
     self.view.backgroundColor = UIColor.white
     
-    self.dataSource = DFIngredientCollectionViewDataSource()
+    self.dataSource = DFIngredientCollectionViewDataSource.init()
     
     let flowLayout = UICollectionViewFlowLayout()
     flowLayout.scrollDirection = UICollectionViewScrollDirection.horizontal

--- a/DogFoodCalculator/DogFoodCalculator/DataAndModels/DFIngredientCollectionViewDataSource.swift
+++ b/DogFoodCalculator/DogFoodCalculator/DataAndModels/DFIngredientCollectionViewDataSource.swift
@@ -9,23 +9,43 @@
 import UIKit
 
 class DFIngredientCollectionViewDataSource: NSObject, UICollectionViewDataSource, UICollectionViewDelegateFlowLayout {
-  func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-    return 10;
-  }
-  
-  func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-    let cell: DFCalculatorCollectionViewCell = collectionView.dequeueReusableCell(withReuseIdentifier: DFCalculatorCollectionViewCell.reuseIdentifier, for: indexPath) as! DFCalculatorCollectionViewCell
-    cell.configureCellWithModel(self.generateRandomIngredient())
-    return cell
-  }
-  
-  func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
-    return CGSize(width: 300, height: 150)
-  }
-
+    let numIngredients: Int = 10
+    var ingredients: [DFIngredientModel] = [DFIngredientModel]()
+    
+    override init() {
+        super.init()
+        
+        self.generateIngredients()
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        return self.numIngredients
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        let cell: DFCalculatorCollectionViewCell = collectionView.dequeueReusableCell(withReuseIdentifier: DFCalculatorCollectionViewCell.reuseIdentifier, for: indexPath) as! DFCalculatorCollectionViewCell
+        cell.configureCellWithModel(self.ingredients[indexPath.row])
+        return cell
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+        return CGSize(width: 300, height: 150)
+    }
+    
 }
 
+// MARK:
+
+// test data generation
+
 extension DFIngredientCollectionViewDataSource {
+    private func generateIngredients() {
+        for _ in 0..<self.numIngredients {
+            self.ingredients.append(self.generateRandomIngredient())
+        }
+        
+    }
+    
     private func generateRandomIngredient() -> DFIngredientModel {
         let randomInt: Int = Int(arc4random_uniform(3))
         switch randomInt {

--- a/DogFoodCalculator/DogFoodCalculator/DataAndModels/DFIngredientModel.swift
+++ b/DogFoodCalculator/DogFoodCalculator/DataAndModels/DFIngredientModel.swift
@@ -10,9 +10,9 @@ import UIKit
 
 class DFIngredientModel: NSObject {
     let ingredientName: String
-    let supportedMeasurementUnits: [DFMeasurementUnit]
-    let defaultMeasurementUnit: DFMeasurementUnit
     var ingredientAmount: DFMeasurement
+    private var defaultMeasurementUnit: DFMeasurementUnit
+    private var supportedMeasurementUnits: [DFMeasurementUnit]
     
     required init(ingredientName: String,
                   supportedMeasurementUnits: [DFMeasurementUnit],
@@ -23,6 +23,21 @@ class DFIngredientModel: NSObject {
         self.ingredientAmount = DFMeasurement(measurementUnit: self.defaultMeasurementUnit, measurementValue: 0)!
         
         super.init()
+        
+        self.setDefaultAndReorderUnitsIfNecessary()
+    }
+    
+    func setDefaultAndReorderUnitsIfNecessary() {
+        if !self.supportedMeasurementUnits.contains(self.defaultMeasurementUnit) {  // default unit not supported, set to first unit
+            self.defaultMeasurementUnit = self.supportedMeasurementUnits[0]
+            self.ingredientAmount = DFMeasurement(measurementUnit: self.defaultMeasurementUnit, measurementValue: 0)!
+        } else if self.supportedMeasurementUnits[0] != self.defaultMeasurementUnit {
+            let defaultIndex = self.supportedMeasurementUnits.index(of: self.defaultMeasurementUnit)
+            self.supportedMeasurementUnits.remove(at: defaultIndex!)
+            self.supportedMeasurementUnits.insert(self.defaultMeasurementUnit, at: 0)
+        }
+        
+        
     }
     
     func selectedMeasurementUnit() -> DFMeasurementUnit {
@@ -31,5 +46,27 @@ class DFIngredientModel: NSObject {
     
     func isSelected() -> Bool {
         return self.ingredientAmount.measurementValue > 0
+    }
+    
+    func measurementUnitViewModels() -> [DFMeasurementUnitViewModel] {
+        var viewModels = [DFMeasurementUnitViewModel]()
+        for unit: DFMeasurementUnit in self.supportedMeasurementUnits {
+            viewModels.append(DFMeasurementUnitViewModel(unit: unit, isSelected: unit == self.selectedMeasurementUnit()))
+        }
+        return viewModels
+    }
+}
+
+// MARK:
+
+// private var getters
+
+extension DFIngredientModel {
+    func getDefaultMeasurementUnit() -> DFMeasurementUnit {
+        return self.defaultMeasurementUnit
+    }
+    
+    func getSupportedMesaurementUnits() -> [DFMeasurementUnit] {
+        return self.supportedMeasurementUnits
     }
 }

--- a/DogFoodCalculator/DogFoodCalculator/DataAndModels/DFMeasurement.swift
+++ b/DogFoodCalculator/DogFoodCalculator/DataAndModels/DFMeasurement.swift
@@ -48,6 +48,16 @@ enum DFMeasurementUnit: String {
     }
 }
 
+struct DFMeasurementUnitViewModel {
+    let measurementUnit: DFMeasurementUnit
+    let isSelected: Bool
+    
+    init(unit: DFMeasurementUnit, isSelected: Bool) {
+        self.measurementUnit = unit
+        self.isSelected = isSelected
+    }
+}
+
 struct DFMeasurement {
     var measurementUnit: DFMeasurementUnit
     var measurementValue: Float

--- a/DogFoodCalculator/DogFoodCalculator/Views/DFCalculatorCollectionViewCell.swift
+++ b/DogFoodCalculator/DogFoodCalculator/Views/DFCalculatorCollectionViewCell.swift
@@ -60,7 +60,7 @@ extension DFCalculatorCollectionViewCell {
     }
     
     private func configureSupportedUnitsRow() {
-        supportedUnitsRow.configureSupportedMeasurementUnits(ingredientModel.supportedMeasurementUnits)
+        supportedUnitsRow.configureSupportedMeasurementUnits(ingredientModel.measurementUnitViewModels())
     }
 }
 

--- a/DogFoodCalculator/DogFoodCalculator/Views/DFSupportedMeasurementUnitsRow.swift
+++ b/DogFoodCalculator/DogFoodCalculator/Views/DFSupportedMeasurementUnitsRow.swift
@@ -33,22 +33,23 @@ class DFSupportedMeasurementUnitsRow: UIView {
         self.supportedMeasurementUnits.removeAll()
     }
     
-    func configureSupportedMeasurementUnits(_ supportedUnits: [DFMeasurementUnit]) {
+    func configureSupportedMeasurementUnits(_ supportedUnits: [DFMeasurementUnitViewModel]) {
         self.resetAllButtons()
         
-        for unit: DFMeasurementUnit in supportedUnits {
-            let button: UIButton = self.buttonForMeasurementUnit(unit)
+        for unit: DFMeasurementUnitViewModel in supportedUnits {
+            let button: UIButton = self.buttonForViewModel(unit)
             self.supportedMeasurementUnits.append(button)
             self.addSubview(button)
         }
     }
     
-    private func buttonForMeasurementUnit(_ unit: DFMeasurementUnit) -> UIButton {
+    private func buttonForViewModel(_ viewModel: DFMeasurementUnitViewModel) -> UIButton {
         let button = UIButton(type: UIButtonType.system)
-        button.setTitle(unit.rawValue, for: UIControlState.normal)
-        button.setTitle(unit.rawValue, for: UIControlState.selected)
+        button.setTitle(viewModel.measurementUnit.rawValue, for: UIControlState.normal)
+        button.setTitle(viewModel.measurementUnit.rawValue, for: UIControlState.selected)
         button.setTitleColor(UIColor.blue, for: UIControlState.normal)
         button.isHidden = false
+        button.isSelected = viewModel.isSelected
         button.backgroundColor = UIColor.white
         button.addTarget(self, action: #selector(self.tappedMeasurementButton(sender:)), for: UIControlEvents.touchUpInside)
         


### PR DESCRIPTION
1/ Generating test ingredients properly in the collection view data source. Before we were just generating new elements on the fly. Now I create an array of random ingredients in the data source init and reference that using indexPath in the collection view data source delegate methods
2/ Using a view model instead of DFMeasurementUnit itself for rendering the supported unit rows. The view model is just a struct that is a wrapper around the unit and a boolean on whether it is selected or not. This view model can be used to display selected state of an ingredient
3/ Made some properties in the ingredient data model private with exposed getters for them so that they cannot be accidentally set from outside the file.
4/ Additional tests for supported units to make sure that the default unit is one of the supported units and that it is listed first in the array